### PR TITLE
Update `es2015-node4` to `es2015`

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["es2015-node4"]
+  "presets": ["es2015"]
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "babel-cli": "^6.4.5",
     "babel-eslint": "5.0.0-beta9",
-    "babel-preset-es2015-node4": "2.0.3",
+    "babel-preset-es2015": "6.5.0",
     "babel-register": "6.4.3",
     "coveralls": "2.11.6",
     "eslint": "1.8.0",


### PR DESCRIPTION
Since we're using this package on browser we can't build the distribution version using `es2015-node4`.

`const`s will not work well in various browsers including Safari latest version.
